### PR TITLE
Fixed a language reference to technical team

### DIFF
--- a/src/app/project/comments/add-survey-response/add-survey-response.component.html
+++ b/src/app/project/comments/add-survey-response/add-survey-response.component.html
@@ -45,7 +45,7 @@
         <h2>How it Works</h2>
         <p>All accepted comments submitted to the <em>{{project?.name || 'project'}}</em> team will be evaluated and considered throughout the
         land use planning process. Comments may be anonymously quoted or summarized in a publicly available ‘What We Heard’ report following
-        the engagement period. Comments will not be considered if - in the technical planning team’s view - they are profane,
+        the engagement period. Comments will not be considered if - in the land use planning team’s view - they are profane,
         abusive or do not relate to the matter being consulted upon.</p>
         <p> All attachments must be no larger than <strong>5MB</strong> and must be a
           <strong>.png, .pdf, .gif, .jpg, .jpeg, or .bmp</strong> file.</p>


### PR DESCRIPTION
Missed a reference to the "technical planning team" that had to be changed. Fixed now.