### PR TITLE
DESENG-92 Fix karma error when running tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 1.1.3 March 28, 2022
+* Fix karma error when running tests [DESENG-92](https://apps.itsm.gov.bc.ca/jira/browse/DESENG-92)
+
 ### 1.1.2 March 28, 2022
 * Replace deprecated node-sass with sass library [DESENG-93](https://apps.itsm.gov.bc.ca/jira/browse/DESENG-93)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "base-app",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "license": "Apache-2.0",
   "scripts": {
     "ng": "ng",
@@ -73,13 +73,12 @@
     "codelyzer": "^4.5.0",
     "jasmine-core": "~2.5.2",
     "jasmine-spec-reporter": "~3.2.0",
-    "karma": "^4.2.0",
+    "karma": "6.3.16",
     "karma-chrome-launcher": "~2.2.0",
     "karma-cli": "~1.0.1",
     "karma-coverage-istanbul-reporter": "^0.2.0",
     "karma-jasmine": "~1.1.1",
     "karma-jasmine-html-reporter": "^0.2.2",
-    "node": "^8.16.0",
     "protractor": "^6.0.0",
     "ts-node": "2.0.0",
     "tslint": "^5.18.0",


### PR DESCRIPTION
Bizarrely, `node` was installed as a dependency, version 8.x.x. Even more bizarrely, when running the `ng test` command via an npm script, the old version of node would be used to run it. Subsequently it would throw an error when an unsupported JS language feature was used(optional catch binding, introduced in Node 10).