### PR TITLE
bugfix/deseng359: Fixed project description images so that they are centre-aligned by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 1.5.2 Jul 5, 2023
+* Fixed project description images so that they are centre-aligned by default. [DESENG-359](https://apps.itsm.gov.bc.ca/jira/browse/DESENG-359)
+
 ### 1.5.1 Jun 15, 2023
 * Updated Angular (version 11) and several packages to address security concerns. [DESENG-344](https://apps.itsm.gov.bc.ca/jira/browse/DESENG-344)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "base-app",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "license": "Apache-2.0",
   "scripts": {
     "ng": "ng",

--- a/src/assets/styles/components/ckeditor.scss
+++ b/src/assets/styles/components/ckeditor.scss
@@ -3,14 +3,19 @@
   figure.image {
     position: relative;
 
+    img {
+      max-width: 100%;
+    }
+
+    img:not(.image-style-side) {
+      margin-left: auto;
+      margin-right: auto;
+    }
+
     &.image-style-side {
       float: right;
       margin-left: 1.5em;
       max-width: 50%;
-
-      img {
-        max-width: 100%;
-      }
     }
   }
 }


### PR DESCRIPTION
- Fixed project description images so that they are centre-aligned by default