### PR TITLE
[DESENG-788] Improve project list screen reader accessibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 1.20.3 Apr 10, 2025
+- Fixed several screen reader accessibility issues in the project list page. [DESENG-788](https://apps.itsm.gov.bc.ca/jira/browse/DESENG-788)
+
 ### 1.20.2 Apr 07, 2025
 
 - Fixed issue with the comment period page not showing the banner image. [DESENG-790](https://apps.itsm.gov.bc.ca/jira/browse/DESENG-790)

--- a/src/app/projects/project-list/project-list-table-rows/project-list-table-rows.component.html
+++ b/src/app/projects/project-list/project-list-table-rows/project-list-table-rows.component.html
@@ -1,7 +1,7 @@
-<tr tabindex="0"
-  (click)="goToProject(project)" (keyup.Enter)="goToProject(project)"
+<tr tabindex="0" role="row" (click)="goToProject(project)" (keyup.enter)="goToProject(project)"
+  [attr.aria-label]="makeAriaLabel(project.name)"
   *ngFor="let project of projects | paginate: { id: 'table-template-pagination', itemsPerPage: paginationData.pageSize, currentPage: paginationData.currentPage, totalItems: paginationData.totalListItems }">
-  <td scope="row" data-label="Name" [attr.aria-label]="makeAriaLabel(project.name)" class="col-4">{{project.name || '-'}}</td>
-  <td scope="row" data-label="Partner First Nation(s)" [attr.aria-hidden]="true" class="col-4">{{project.partner || '-'}}</td>
-  <td scope="row" data-label="Project Phase" [attr.aria-hidden]="true" class="col-4">{{project.projectTypes || '-'}}</td>
+  <td role="cell" scope="row" [ngClass]="'col-4 project-table__name-col'">{{project.name || '-'}}</td>
+  <td role="cell" scope="row" [ngClass]="'col-4 project-table__name-col'">{{project.partner || '-'}}</td>
+  <td role="cell" scope="row" [ngClass]="'col-4 project-table__name-col'">{{project.projectTypes || '-'}}</td>
 </tr>

--- a/src/app/projects/project-list/project-list-table-rows/project-list-table-rows.component.html
+++ b/src/app/projects/project-list/project-list-table-rows/project-list-table-rows.component.html
@@ -1,7 +1,7 @@
 <tr tabindex="0" role="row" (click)="goToProject(project)" (keyup.enter)="goToProject(project)"
   [attr.aria-label]="makeAriaLabel(project.name)"
   *ngFor="let project of projects | paginate: { id: 'table-template-pagination', itemsPerPage: paginationData.pageSize, currentPage: paginationData.currentPage, totalItems: paginationData.totalListItems }">
-  <td role="cell" scope="row" [ngClass]="'col-4 project-table__name-col'">{{project.name || '-'}}</td>
-  <td role="cell" scope="row" [ngClass]="'col-4 project-table__name-col'">{{project.partner || '-'}}</td>
-  <td role="cell" scope="row" [ngClass]="'col-4 project-table__name-col'">{{project.projectTypes || '-'}}</td>
+  <td role="cell" [ngClass]="'col-4 project-table__name-col'">{{project.name || '-'}}</td>
+  <td role="cell" [ngClass]="'col-4 project-table__name-col'">{{project.partner || '-'}}</td>
+  <td role="cell" [ngClass]="'col-4 project-table__name-col'">{{project.projectTypes || '-'}}</td>
 </tr>

--- a/src/app/shared/components/table-template/table-template.component.html
+++ b/src/app/shared/components/table-template/table-template.component.html
@@ -1,15 +1,13 @@
 <table class="table">
   <thead class="thead-light">
     <tr class="no-sort">
-      <th *ngFor="let entry of columns"
-        class="project-table__name-col sortable"
-        (click)="!entry.nosort && sort(entry.value)"
-        [ngClass]="entry.width"
-        >
+      <th *ngFor="let entry of columns" class="project-table__name-col sortable"
+        (click)="!entry.nosort && sort(entry.value)" (keyup.enter)="!entry.nosort && sort(entry.value)" tabindex="0"
+        role="columnheader" [attr.aria-label]="entry.name + ' column; click to sort'" [ngClass]="entry.width">
         {{entry.name}}
         <i *ngIf="entry.nosort !== true" class="sort"
-            [ngClass]="{'sort-asc': (column.slice(1) == entry.value && column.charAt(0) === '+'), 'sort-desc': (column.slice(1) == entry.value && column.charAt(0) === '-')}"
-            aria-hidden="true"></i>
+          [ngClass]="{'sort-asc': (column.slice(1) == entry.value && column.charAt(0) === '+'), 'sort-desc': (column.slice(1) == entry.value && column.charAt(0) === '-')}"
+          aria-hidden="true"></i>
       </th>
     </tr>
   </thead>
@@ -21,4 +19,3 @@
   <pagination-controls (pageChange)="updatePageNumber($event)" id="table-template-pagination" autoHide="true">
   </pagination-controls>
 </div>
-  


### PR DESCRIPTION
https://citz-gdx.atlassian.net/browse/DESENG-788

Fixed issues:
☑️ The column headers are read as headers when using a screen reader
☑️ The column headers announce their sort actions. `${entry.name} column; click to sort`
☑️ The column headers are “clickable” with keyboard using the enter key.
☑️ When using a screenreader, the project listings read the following message aloud: `View more information about the ${projName} project. Link.`;
☑️The project list entry in the table redirects to the named project when the enter key is pressed.
☑️Tested & verified using NVDA screen reader.