### PR TITLE
Always display environment banner in public view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Dec 22, 2025
+- Update environemnt banner component to read from correct localStorage key [DESENG-924](https://citz-gdx.atlassian.net/browse/DESENG-924)
+
 ### Nov 13, 2025
 - Added robots.txt and sitemap.xml files for improved SEO and web crawler guidance. [DESENG-917](https://citz-gdx.atlassian.net/browse/DESENG-917)
   - Created robots.txt to manage crawler access and behavior.

--- a/src/app/header/env-banner/env-banner.component.ts
+++ b/src/app/header/env-banner/env-banner.component.ts
@@ -12,7 +12,7 @@ export class EnvBannerComponent implements OnInit {
   public showBanner: boolean;
 
   constructor() {
-    const deployment_env = window.localStorage.getItem('from_admin_server--deployment_env');
+    const deployment_env = window.localStorage.getItem('from_public_server--deployment_env');
 
     this.env = (isEmpty(deployment_env)) ? 'prod' : deployment_env;
     if (this.env.toUpperCase() === 'PROD') {


### PR DESCRIPTION
[DESENG-924](https://citz-gdx.atlassian.net/browse/DESENG-924)
Update environemnt banner component to read from correct localStorage key, fixing an issue where the banner would not display when it should unless the current user had a localStorage entry from the admin-facing server. 