### PR TITLE
feature/deseng935: Changed wording of two static fields for comment period response modals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### Feb 19, 2026
+- Small wording updates to comment period [DESENG-924](https://citz-gdx.atlassian.net/browse/DESENG-935)
+  - Changed "Submit a Comment" heading to "Participate Now" 
+  - Changed "All accepted comments submitted" to "All submissions"
+
 ### Dec 22, 2025
 - Update environemnt banner component to read from correct localStorage key [DESENG-924](https://citz-gdx.atlassian.net/browse/DESENG-924)
 

--- a/src/app/project/comments/add-comment/add-comment.component.html
+++ b/src/app/project/comments/add-comment/add-comment.component.html
@@ -13,7 +13,7 @@
 <form #preCommentForm="ngForm" cdkTrapFocus>
   <div class="modal-content" *ngIf="this.currentPage === 1">
     <div class="modal-header">
-      <h4 class="modal-title">Submit a Comment</h4>
+      <h4 class="modal-title">Participate Now</h4>
       <button class="btn btn-icon close-btn gtm-submit-comment_cancel-pg1" type="button" aria-label="Close"
         (click)="activeModal.dismiss('dismissed page1')">
         <i class="material-icons">
@@ -25,7 +25,7 @@
     <div *ngIf="this.commentingMethod !== 'externalEngagementTool' else externalToolText" class="modal-body">
       <section>
         <h2>How it Works</h2>
-        <p>All accepted comments submitted to the <em>{{project?.name || 'project'}}</em> team will be evaluated and considered throughout the
+        <p>All submissions to the <em>{{project?.name || 'project'}}</em> team will be evaluated and considered throughout the
         land use planning process. Comments may be anonymously quoted or summarized in a publicly available ‘What We Heard’ report following
         the engagement period. Comments will not be considered if - in the Land Use Planning team’s view - they are profane,
         abusive or do not relate to the matter being consulted upon.</p>
@@ -60,7 +60,7 @@
 <form #commentForm1="ngForm" (ngSubmit)="register()" cdkTrapFocus>
   <div class="modal-content" *ngIf="this.currentPage === 2">
     <div class="modal-header">
-      <h4 class="modal-title">Submit a Comment</h4>
+      <h4 class="modal-title">Participate Now</h4>
       <button class="btn btn-icon close-btn gtm-submit-comment-cancel-pg2" type="button" aria-label="Close comment submission form."
         (click)="activeModal.dismiss('dismissed page2')">
         <i class="material-icons" aria-hidden="true">

--- a/src/app/project/comments/add-survey-response/add-survey-response.component.html
+++ b/src/app/project/comments/add-survey-response/add-survey-response.component.html
@@ -43,7 +43,7 @@
     <div class="modal-body">
       <section>
         <h2>How it Works</h2>
-        <p>All submissions to the to the <em>{{project?.name || 'project'}}</em> team will be evaluated and considered throughout the
+        <p>All submissions to the <em>{{project?.name || 'project'}}</em> team will be evaluated and considered throughout the
         land use planning process. Comments may be anonymously quoted or summarized in a publicly available ‘What We Heard’ report following
         the engagement period. Comments will not be considered if - in the land use planning team’s view - they are profane,
         abusive or do not relate to the matter being consulted upon.</p>

--- a/src/app/project/comments/add-survey-response/add-survey-response.component.html
+++ b/src/app/project/comments/add-survey-response/add-survey-response.component.html
@@ -3,7 +3,7 @@
 <!-- FIRST PAGE -->
 <form cdkTrapFocus>
   <div class="modal-header">
-    <h4 class="modal-title">Submit a Comment</h4>
+    <h4 class="modal-title">Participate Now</h4>
     <button class="btn btn-icon close-btn gtm-submit-comment_cancel-pg1" type="button" aria-label="Close"
       (click)="closeDialog()">
       <i class="material-icons">
@@ -43,7 +43,7 @@
     <div class="modal-body">
       <section>
         <h2>How it Works</h2>
-        <p>All accepted comments submitted to the <em>{{project?.name || 'project'}}</em> team will be evaluated and considered throughout the
+        <p>All submissions to the to the <em>{{project?.name || 'project'}}</em> team will be evaluated and considered throughout the
         land use planning process. Comments may be anonymously quoted or summarized in a publicly available ‘What We Heard’ report following
         the engagement period. Comments will not be considered if - in the land use planning team’s view - they are profane,
         abusive or do not relate to the matter being consulted upon.</p>


### PR DESCRIPTION
- Small wording updates to comment period [DESENG-924](https://citz-gdx.atlassian.net/browse/DESENG-935)
  - Changed "Submit a Comment" heading to "Participate Now" 
  - Changed "All accepted comments submitted" to "All submissions"