### PR TITLE
bugfix/deseng959: Added proper switching for participate button. Refactored documents tab to pass unit test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### Apr 24, 2026
+- Made external links available from the public side [DESENG-959](https://citz-gdx.atlassian.net/browse/DESENG-959)
+  - Refactored code for Participate Now button handling
+  - Applied to three locations (main Project page, comment period page, project engagement tab)
+
 ### Apr 13, 2026
 - Fixed dead search functionality on project list page [DESENG-955](https://citz-gdx.atlassian.net/browse/DESENG-955)
   - Converted site to use query params instead of route params

--- a/src/app/project/commenting-tab/commenting-tab.component.html
+++ b/src/app/project/commenting-tab/commenting-tab.component.html
@@ -26,7 +26,7 @@
                         [attr.aria-label]="'View details of ' + (currentProject?.engagementLabel || 'this comment period')">
                         View details
                     </button>
-                    <button (click)=addComment() *ngIf="commentPeriod?.commentPeriodStatus === 'Open'"
+                    <button (click)=handleParticipate() *ngIf="commentPeriod?.commentPeriodStatus === 'Open'"
                         class="badge badge-secondary p-3"
                         [attr.aria-label]="'Participate now in ' + (currentProject?.engagementLabel || 'this comment period')">
                         Participate now

--- a/src/app/project/commenting-tab/commenting-tab.component.ts
+++ b/src/app/project/commenting-tab/commenting-tab.component.ts
@@ -1,7 +1,7 @@
-import { Component, OnInit, OnDestroy, ChangeDetectorRef, ViewEncapsulation } from '@angular/core';
+import { Component, OnInit, OnDestroy, ChangeDetectorRef, ViewEncapsulation, Input } from '@angular/core';
 import { trigger, style, transition, animate } from '@angular/animations';
 import { ActivatedRoute, Router } from '@angular/router';
-import { NgbModal, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
+import { NgbModal, NgbModalOptions, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
 import { Subject } from 'rxjs';
 import 'rxjs/add/operator/takeUntil';
 
@@ -12,6 +12,7 @@ import { SurveyService } from 'app/services/survey.service';
 import { Survey } from 'app/models/survey';
 import { AddSurveyResponseComponent } from '../comments/add-survey-response/add-survey-response.component';
 import { AddCommentComponent } from '../comments/add-comment/add-comment.component';
+import { ExternalLinkComponent } from '../comments/external-link/external-link.component';
 
 @Component({
   templateUrl: './commenting-tab.component.html',
@@ -78,26 +79,51 @@ export class CommentingTabComponent implements OnInit, OnDestroy {
       });
   }
 
-  public addComment() {
-    if (this.currentProject.commentPeriodForBanner) {
-      this.surveyService.getSelectedSurveyByCPId(this.currentProject.commentPeriodForBanner._id)
-        .subscribe((loadedSurvey: Survey) => {
-          if (loadedSurvey) {
-            // open modal
-            this.ngbModal = this.modalService.open(AddSurveyResponseComponent, { ariaLabelledBy: 'modal-instructions', backdrop: 'static', size: 'xl' as 'lg', keyboard: false });
-            // set input parameter
-            (<AddSurveyResponseComponent>this.ngbModal.componentInstance).currentPeriod = this.currentProject.commentPeriodForBanner;
-            (<AddSurveyResponseComponent>this.ngbModal.componentInstance).project = this.currentProject;
-            (<AddSurveyResponseComponent>this.ngbModal.componentInstance).survey = loadedSurvey;
-          } else {
-            // open modal
-            this.ngbModal = this.modalService.open(AddCommentComponent, { ariaLabelledBy: 'modal-instructions', backdrop: 'static', size: 'xl' as 'lg' });
-            // set input parameter
-            (<AddCommentComponent>this.ngbModal.componentInstance).currentPeriod = this.currentProject.commentPeriodForBanner;
-            (<AddCommentComponent>this.ngbModal.componentInstance).project = this.currentProject;
-          }
-      })
+  public handleParticipate() {
+    const method = this.currentProject.commentPeriodForBanner?.commentingMethod;
+    if (!method) {return; }
+    switch (method) {
+      case 'externalEngagementTool':
+        this.openExternalLinkModal();
+        break;
+      case 'surveyTool':
+        this.openSurveyModal();
+        break;
+      case 'basicForm':
+        this.openCommentModal();
+        break;
+      default:
+        console.error('Unknown commenting method:', method);
     }
+  }
+
+  public openExternalLinkModal() {
+    const options = { ariaLabelledBy: 'modal-instructions', backdrop: 'static', size: 'xl' as 'lg', keyboard: false } as NgbModalOptions;
+    this.ngbModal = this.modalService.open(ExternalLinkComponent, options);
+    const instance = <ExternalLinkComponent>this.ngbModal.componentInstance as ExternalLinkComponent;
+    instance.externalLinkText = this.currentProject?.commentPeriodForBanner?.externalToolPopupText;
+  }
+
+  public openSurveyModal() {
+    this.surveyService.getSelectedSurveyByCPId(this.currentProject?.commentPeriodForBanner?._id)
+      .subscribe((loadedSurvey: Survey) => {
+        if (loadedSurvey) {
+          const options = { ariaLabelledBy: 'modal-instructions', backdrop: 'static', size: 'xl' as 'lg', keyboard: false } as NgbModalOptions;
+          this.ngbModal = this.modalService.open(AddSurveyResponseComponent, options);
+          const instance = <AddSurveyResponseComponent>this.ngbModal.componentInstance as AddSurveyResponseComponent;
+          instance.currentPeriod = this.currentProject?.commentPeriodForBanner;
+          instance.project = this.currentProject;
+          instance.survey = loadedSurvey;
+        }
+    });
+  }
+
+  public openCommentModal() {
+    const options = { ariaLabelledBy: 'modal-instructions', backdrop: 'static', size: 'xl' as 'lg' } as NgbModalOptions;
+    this.ngbModal = this.modalService.open(AddCommentComponent, options);
+    const instance = <AddCommentComponent>this.ngbModal.componentInstance as AddCommentComponent;
+    instance.currentPeriod = this.currentProject?.commentPeriodForBanner;
+    instance.project = this.currentProject;
   }
 
   ngOnDestroy() {

--- a/src/app/project/comments/comments.component.html
+++ b/src/app/project/comments/comments.component.html
@@ -48,7 +48,7 @@
               </div>
 
               <div class="buttons-row">
-                <button class="btn btn-light" (click)="addComment()" type="button"
+                <button class="btn btn-light" (click)="handleParticipate()" type="button"
                   *ngIf="commentPeriod.commentPeriodStatus === 'Open'" [attr.aria-label]=makeAriaLabel(project.name)>
                   Participate Now
                 </button>

--- a/src/app/project/comments/comments.component.ts
+++ b/src/app/project/comments/comments.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit, ChangeDetectorRef, OnDestroy } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { forkJoin, Observable, Subject } from 'rxjs';
-import { NgbModal, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
+import { NgbModal, NgbModalOptions, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
 import { isEmpty } from 'lodash';
 import { CommentPeriod } from 'app/models/commentperiod';
 import { Comment } from 'app/models/comment';
@@ -20,6 +20,7 @@ import { Document } from 'app/models/document';
 import { Utils } from 'app/shared/utils/utils';
 import { SurveyService } from 'app/services/survey.service';
 import { Survey } from 'app/models/survey';
+import { ExternalLinkComponent } from './external-link/external-link.component';
 
 type CommentPeriodFile = Document & ExternalLink;
 
@@ -211,30 +212,51 @@ export class CommentsComponent implements OnInit, OnDestroy {
     }
   }
 
-  /**
-   * Triggers the opening of the survey dialog and opens the appropriate survey based on available data.
-   *
-   */
-  public addComment(): void {
-    if (this.project.commentPeriodForBanner) {
-      this.surveyService.getSelectedSurveyByCPId(this.project.commentPeriodForBanner._id)
-        .subscribe((loadedSurvey: Survey) => {
-          if (loadedSurvey) {
-            // open modal
-            this.ngbModal = this.modalService.open(AddSurveyResponseComponent, { ariaLabelledBy: 'modal-instructions', backdrop: 'static', size: 'xl' as 'lg', keyboard: false });
-            // set input parameter
-            (<AddSurveyResponseComponent>this.ngbModal.componentInstance).currentPeriod = this.project.commentPeriodForBanner;
-            (<AddSurveyResponseComponent>this.ngbModal.componentInstance).project = this.project;
-            (<AddSurveyResponseComponent>this.ngbModal.componentInstance).survey = loadedSurvey;
-          } else {
-            // open modal
-            this.ngbModal = this.modalService.open(AddCommentComponent, { ariaLabelledBy: 'modal-instructions', backdrop: 'static', size: 'xl' as 'lg' });
-            // set input parameter
-            (<AddCommentComponent>this.ngbModal.componentInstance).currentPeriod = this.project.commentPeriodForBanner;
-            (<AddCommentComponent>this.ngbModal.componentInstance).project = this.project;
-          }
-        });
+  public handleParticipate() {
+    const method = this.project.commentPeriodForBanner?.commentingMethod;
+    if (!method) {return; }
+    switch (method) {
+      case 'externalEngagementTool':
+        this.openExternalLinkModal();
+        break;
+      case 'surveyTool':
+        this.openSurveyModal();
+        break;
+      case 'basicForm':
+        this.openCommentModal();
+        break;
+      default:
+        console.error('Unknown commenting method:', method);
     }
+  }
+
+  public openExternalLinkModal() {
+    const options = { ariaLabelledBy: 'modal-instructions', backdrop: 'static', size: 'xl' as 'lg', keyboard: false } as NgbModalOptions;
+    this.ngbModal = this.modalService.open(ExternalLinkComponent, options);
+    const instance = <ExternalLinkComponent>this.ngbModal.componentInstance as ExternalLinkComponent;
+    instance.externalLinkText = this.project?.commentPeriodForBanner?.externalToolPopupText;
+  }
+
+  public openSurveyModal() {
+    this.surveyService.getSelectedSurveyByCPId(this.project?.commentPeriodForBanner?._id)
+      .subscribe((loadedSurvey: Survey) => {
+        if (loadedSurvey) {
+          const options = { ariaLabelledBy: 'modal-instructions', backdrop: 'static', size: 'xl' as 'lg', keyboard: false } as NgbModalOptions;
+          this.ngbModal = this.modalService.open(AddSurveyResponseComponent, options);
+          const instance = <AddSurveyResponseComponent>this.ngbModal.componentInstance as AddSurveyResponseComponent;
+          instance.currentPeriod = this.project?.commentPeriodForBanner;
+          instance.project = this.project;
+          instance.survey = loadedSurvey;
+        }
+    });
+  }
+
+  public openCommentModal() {
+    const options = { ariaLabelledBy: 'modal-instructions', backdrop: 'static', size: 'xl' as 'lg' } as NgbModalOptions;
+    this.ngbModal = this.modalService.open(AddCommentComponent, options);
+    const instance = <AddCommentComponent>this.ngbModal.componentInstance as AddCommentComponent;
+    instance.currentPeriod = this.project?.commentPeriodForBanner;
+    instance.project = this.project;
   }
 
   public goBackToProjectDetails() {

--- a/src/app/project/comments/external-link/external-link.component.html
+++ b/src/app/project/comments/external-link/external-link.component.html
@@ -15,7 +15,7 @@
     <section>
       <h2>How it Works</h2>
       <p>
-        All submissions to the <em>{{project?.name || 'project'}}</em> team will be evaluated and considered throughout the
+        All submissions to the <em>{{currentProject?.name || 'project'}}</em> team will be evaluated and considered throughout the
         land use planning process. Comments may be anonymously quoted or summarized in a publicly available 'What We Heard' report following
         the engagement period. Comments will not be considered if - in the Land Use Planning team's view - they are profane,
         abusive or do not relate to the matter being consulted upon.

--- a/src/app/project/comments/external-link/external-link.component.html
+++ b/src/app/project/comments/external-link/external-link.component.html
@@ -1,0 +1,27 @@
+<div id="modal-instructions">Use tab to navigate form elements. Escape key to close.</div>
+
+<div class="modal-content">
+  <div class="modal-header">
+    <h4 class="modal-title">Participate Now</h4>
+    <button class="btn btn-icon close-btn gtm-submit-comment_cancel-pg1" type="button" aria-label="Close"
+      (click)="activeModal.dismiss('dismissed page1')">
+      <i class="material-icons">
+        close
+      </i>
+    </button>
+  </div>
+
+  <div class="modal-body">
+    <section>
+      <h2>How it Works</h2>
+      <p>
+        All submissions to the <em>{{project?.name || 'project'}}</em> team will be evaluated and considered throughout the
+        land use planning process. Comments may be anonymously quoted or summarized in a publicly available 'What We Heard' report following
+        the engagement period. Comments will not be considered if - in the Land Use Planning team's view - they are profane,
+        abusive or do not relate to the matter being consulted upon.
+      </p>
+      <p *ngIf="externalLinkText" class="modal-body" [innerHTML]="externalLinkText"></p>
+    </section>
+      
+  </div>
+</div>

--- a/src/app/project/comments/external-link/external-link.component.html
+++ b/src/app/project/comments/external-link/external-link.component.html
@@ -15,7 +15,7 @@
     <section>
       <h2>How it Works</h2>
       <p>
-        All submissions to the <em>{{currentProject?.name || 'project'}}</em> team will be evaluated and considered throughout the
+        All submissions to the project team will be evaluated and considered throughout the
         land use planning process. Comments may be anonymously quoted or summarized in a publicly available 'What We Heard' report following
         the engagement period. Comments will not be considered if - in the Land Use Planning team's view - they are profane,
         abusive or do not relate to the matter being consulted upon.

--- a/src/app/project/comments/external-link/external-link.component.scss
+++ b/src/app/project/comments/external-link/external-link.component.scss
@@ -1,0 +1,25 @@
+@import "~assets/styles/base/base.scss";
+
+.modal-content {
+  h4, h5 {
+    font-weight: 600;
+  }
+
+  h5 {
+    margin-bottom: 0.5rem;
+  }
+}
+
+#modal-instructions {
+  display: none;
+}
+
+.modal-footer {
+  .btn {
+    min-width: 6rem;
+    font-size: 0.875rem;
+    font-weight: 700;
+  }
+}
+
+

--- a/src/app/project/comments/external-link/external-link.component.spec.ts
+++ b/src/app/project/comments/external-link/external-link.component.spec.ts
@@ -1,0 +1,39 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ExternalLinkComponent } from './external-link.component';
+import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
+import { CommentService } from 'app/services/comment.service';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { of } from 'rxjs';
+import { Comment } from 'app/models/comment';
+import { ConfigService } from 'app/services/config.service';
+
+describe('ExternalLinkComponent', () => {
+  let component: ExternalLinkComponent;
+  let fixture: ComponentFixture<ExternalLinkComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        ExternalLinkComponent
+      ],
+      providers: [
+        NgbActiveModal,
+        { provide: CommentService, useValue: { add: () => of(new Comment({ _id: '123' })) } },
+        { provide: ConfigService, useValue: { lists: [{ searchResults: [{ type: 'author', name: 'Public' }] }] } }
+      ],
+      schemas: [NO_ERRORS_SCHEMA]
+    })
+      .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ExternalLinkComponent);
+    component = fixture.componentInstance;
+    component.externalLinkText = '<p>This is the text for the external link <a href="https://www.notarealwebsitedontgohere.com">Not a real website</a></p>';
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/project/comments/external-link/external-link.component.ts
+++ b/src/app/project/comments/external-link/external-link.component.ts
@@ -1,0 +1,25 @@
+import { Component, Input } from '@angular/core';
+import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
+import 'rxjs/add/operator/toPromise';
+import 'rxjs/add/observable/forkJoin';
+
+@Component({
+  templateUrl: './external-link.component.html',
+  styleUrls: ['./external-link.component.scss']
+})
+
+export class ExternalLinkComponent {
+  @Input() externalLinkText: string;
+
+  constructor(
+    public activeModal: NgbActiveModal,
+  ) {}
+
+  register() {
+  }
+
+  makeAriaLabel(docName: string) {
+    const docPhrase = docName ?? 'this';
+    return `Remove ${docPhrase} uploaded document.`;
+  }
+}

--- a/src/app/project/documents/documents-tab.component.spec.ts
+++ b/src/app/project/documents/documents-tab.component.spec.ts
@@ -45,7 +45,7 @@ describe('DocumentsTabComponent', () => {
       declarations: [ DocumentsTabComponent ],
       imports: [RouterTestingModule],
       providers: [
-        { provide: ActivatedRoute, useValue: { data: of(routeData), params: of({ currentPage: 1, pageSize: 10, sortBy: '-dateAdded' }) } },
+        { provide: ActivatedRoute, useValue: { data: of(routeData), params: of({ currentPage: 1, pageSize: 10, sortBy: '-dateAdded' }), queryParams: of({}) } },
         { provide: ApiService, useValue: { openDocument: jasmine.createSpy('openDocument'), downloadDocument: jasmine.createSpy('downloadDocument') } },
         { provide: SearchService, useValue: {} },
         { provide: StorageService, useValue: { state: { currentProject: { data: new Project({ _id: 'proj-1', name: 'Project 1' }) } } } },

--- a/src/app/project/documents/documents-tab.component.ts
+++ b/src/app/project/documents/documents-tab.component.ts
@@ -114,24 +114,20 @@ export class DocumentsTabComponent implements OnInit, OnDestroy {
    * This can be called after the document and document file sections have been loaded.
    */
   updateTableDataAndParams(): void {
-    if (this.documents.find(document => document.section)) {
       this.route.queryParams
         .takeUntil(this.ngUnsubscribe)
         .subscribe(params => {
-          // Copy router params and update the page size value.
-          const updatedParams = {
-            ...params,
-            pageSize: 100
+          const section = this.documents.find((document: Document) => document.section);
+          if (section) {
+            const updatedParams = {
+              ...params,
+              pageSize: 100
+            }
+            this.tableParams = this.tableTemplateUtils.getParamsFromUrl(updatedParams);
+            return;
           }
-          this.tableParams = this.tableTemplateUtils.getParamsFromUrl(updatedParams);
+          this.tableParams = this.tableTemplateUtils.getParamsFromUrl(params);
         });
-    } else {
-      this.route.queryParams
-      .takeUntil(this.ngUnsubscribe)
-      .subscribe(params => {
-        this.tableParams = this.tableTemplateUtils.getParamsFromUrl(params)
-      });
-    }
   }
 
   /**

--- a/src/app/project/project.component.html
+++ b/src/app/project/project.component.html
@@ -54,7 +54,7 @@
             <button type="button" class="btn btn-light" (click)="goToViewComments()" [attr.aria-label]="CPActionAriaLabel(project.name, 'view')">
               View Details
             </button>
-            <button class="btn btn-light" (click)="addComment()" type="button" *ngIf="project.commentPeriodForBanner.commentPeriodStatus === 'Open'" [attr.aria-label]="CPActionAriaLabel(project.name, 'submit')">
+            <button class="btn btn-light" (click)="handleParticipate()" type="button" *ngIf="project.commentPeriodForBanner.commentPeriodStatus === 'Open'" [attr.aria-label]="CPActionAriaLabel(project.name, 'submit')">
               Participate Now
             </button>
           </div>

--- a/src/app/project/project.component.ts
+++ b/src/app/project/project.component.ts
@@ -3,7 +3,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { Subject } from 'rxjs';
 import 'rxjs/add/operator/takeUntil';
 import { isEmpty } from 'lodash';
-import { NgbModal, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
+import { NgbModal, NgbModalOptions, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
 
 import { Project, ProjectLogo, ProjectLogoWithSource } from 'app/models/project';
 import { Document } from 'app/models/document';
@@ -19,6 +19,7 @@ import { AddCommentComponent } from './comments/add-comment/add-comment.componen
 import { AddSurveyResponseComponent } from './comments/add-survey-response/add-survey-response.component';
 import { EmailSubscribeComponent } from './email-subscribe/email-subscribe.component';
 import { ContactFormComponent } from './contact-form/contact-form.component';
+import { ExternalLinkComponent } from './comments/external-link/external-link.component';
 
 @Component({
   selector: 'app-project',
@@ -127,30 +128,51 @@ export class ProjectComponent implements OnInit, AfterViewInit, OnDestroy {
     return sourceUrl;
   }
 
-  public addComment() {
-    if (this.project.commentPeriodForBanner) {
-        this.surveyService.getSelectedSurveyByCPId(this.project.commentPeriodForBanner._id)
-        .subscribe((loadedSurvey: Survey) => {
-          if (loadedSurvey) {
-
-          // open modal
-          this.ngbModal = this.modalService.open(AddSurveyResponseComponent, { ariaLabelledBy: 'modal-instructions', backdrop: 'static', size: 'xl' as 'lg', keyboard: false });
-          // set input parameter
-          (<AddSurveyResponseComponent>this.ngbModal.componentInstance).currentPeriod = this.project.commentPeriodForBanner;
-          (<AddSurveyResponseComponent>this.ngbModal.componentInstance).project = this.project;
-          (<AddSurveyResponseComponent>this.ngbModal.componentInstance).survey = loadedSurvey;
-
-        } else {
-
-          // open modal
-          this.ngbModal = this.modalService.open(AddCommentComponent, { ariaLabelledBy: 'modal-instructions', backdrop: 'static', size: 'xl' as 'lg' });
-          // set input parameter
-          (<AddCommentComponent>this.ngbModal.componentInstance).currentPeriod = this.project.commentPeriodForBanner;
-          (<AddCommentComponent>this.ngbModal.componentInstance).project = this.project;
-        }
-      })
-
+  public handleParticipate() {
+    const method = this.project.commentPeriodForBanner?.commentingMethod;
+    if (!method) {return; }
+    switch (method) {
+      case 'externalEngagementTool':
+        this.openExternalLinkModal();
+        break;
+      case 'surveyTool':
+        this.openSurveyModal();
+        break;
+      case 'basicForm':
+        this.openCommentModal();
+        break;
+      default:
+        console.error('Unknown commenting method:', method);
     }
+  }
+
+  public openExternalLinkModal() {
+    const options = { ariaLabelledBy: 'modal-instructions', backdrop: 'static', size: 'xl' as 'lg', keyboard: false } as NgbModalOptions;
+    this.ngbModal = this.modalService.open(ExternalLinkComponent, options);
+    const instance = <ExternalLinkComponent>this.ngbModal.componentInstance as ExternalLinkComponent;
+    instance.externalLinkText = this.project?.commentPeriodForBanner?.externalToolPopupText;
+  }
+
+  public openSurveyModal() {
+    this.surveyService.getSelectedSurveyByCPId(this.project?.commentPeriodForBanner?._id)
+      .subscribe((loadedSurvey: Survey) => {
+        if (loadedSurvey) {
+          const options = { ariaLabelledBy: 'modal-instructions', backdrop: 'static', size: 'xl' as 'lg', keyboard: false } as NgbModalOptions;
+          this.ngbModal = this.modalService.open(AddSurveyResponseComponent, options);
+          const instance = <AddSurveyResponseComponent>this.ngbModal.componentInstance as AddSurveyResponseComponent;
+          instance.currentPeriod = this.project?.commentPeriodForBanner;
+          instance.project = this.project;
+          instance.survey = loadedSurvey;
+        }
+    });
+  }
+
+  public openCommentModal() {
+    const options = { ariaLabelledBy: 'modal-instructions', backdrop: 'static', size: 'xl' as 'lg' } as NgbModalOptions;
+    this.ngbModal = this.modalService.open(AddCommentComponent, options);
+    const instance = <AddCommentComponent>this.ngbModal.componentInstance as AddCommentComponent;
+    instance.currentPeriod = this.project?.commentPeriodForBanner;
+    instance.project = this.project;
   }
 
   public addEmail() {


### PR DESCRIPTION
- Made external links available from the public side [DESENG-959](https://citz-gdx.atlassian.net/browse/DESENG-959)
  - Refactored code for Participate Now button handling
  - Applied to three locations (main Project page, comment period page, project engagement tab)
- Refactored documents tab code to pass queryParams unit test